### PR TITLE
Add 1 more test case for 'C01P11'

### DIFF
--- a/C01-Python-Basics/22-C01P11/README.md
+++ b/C01-Python-Basics/22-C01P11/README.md
@@ -27,4 +27,5 @@ anagrams("listen", "silent") is True
 anagrams("LISTEN", "silent") is True
 anagrams("python", "ruby") is False
 anagrams("New York Times", "monkeys write") is True
+anagrams("snake", "sssnakee") is False
 ```


### PR DESCRIPTION
Adding a corner case in which the sets of the symbols of the two words are equal, but the lengths aren't