### PR TITLE
Fix video link for C03P02S01

### DIFF
--- a/C03-Unit-Testing/05-C03P02/Solution01/README.md
+++ b/C03-Unit-Testing/05-C03P02/Solution01/README.md
@@ -1,4 +1,4 @@
 # C03P02S01 - Interval extended, tests Solution 01
 
 1. Check [solution](./interval_tests.py)
-1. Check the [video](https://www.youtube.com/watch?v=ZhZcQmGrYB4)
+1. Check the [video](https://www.youtube.com/watch?v=rCFtMNaPvqg)


### PR DESCRIPTION
The link for `C03P02S01` was leading to the video for `C03P01S01`. This PR fixes the link.